### PR TITLE
refactor(cookie-size): limit the amount of user information stored

### DIFF
--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -3,7 +3,8 @@ import { concurrentUserA, concurrentUserB, user, password as userPassword } from
 
 export const validResponse = {
   refresh_token: 'valid',
-  access_token: 'valid'
+  access_token: 'valid',
+  token_type: 'grant'
 };
 
 export const handlers = [
@@ -11,19 +12,21 @@ export const handlers = [
     const { email, password, refresh_token } = JSON.parse(req.body as string);
 
     if (refresh_token) {
-      if (refresh_token === 'userA') return res(ctx.status(200), ctx.json({ ...validResponse, ...concurrentUserA }));
+      if (refresh_token === 'userA')
+        return res(ctx.status(200), ctx.json({ ...validResponse, user: { id: concurrentUserA.id } }));
 
-      if (refresh_token === 'userB') return res(ctx.status(200), ctx.json({ ...validResponse, ...concurrentUserB }));
+      if (refresh_token === 'userB')
+        return res(ctx.status(200), ctx.json({ ...validResponse, user: { id: concurrentUserB.id } }));
 
       if (refresh_token !== 'valid') return res(ctx.status(401), ctx.json({ error: 'Token expired' }));
 
-      return res(ctx.status(200), ctx.json({ ...validResponse, user: { email } }));
+      return res(ctx.status(200), ctx.json({ ...validResponse, user: { id: user.id } }));
     }
 
     if (!email || !password || password !== userPassword)
       return res(ctx.status(401), ctx.json({ message: 'Wrong email or password' }));
 
-    return res(ctx.status(200), ctx.json({ ...validResponse, user: { email } }));
+    return res(ctx.status(200), ctx.json({ ...validResponse, user: { id: user.id } }));
   }),
   rest.get('http://supabase-url.com/supabase-project/auth/v1/user', async (req, res, ctx) => {
     const token = req.headers.get('authorization')?.split('Bearer ')?.[1];

--- a/src/test/authenticate.test.ts
+++ b/src/test/authenticate.test.ts
@@ -51,6 +51,6 @@ describe('authenticate', async () => {
           body: fData
         })
       )
-      .then((res) => expect(res).toEqual({ ...validResponse, user: { email: user.email } }));
+      .then((res) => expect(res).toEqual({ ...validResponse, user: { id: user.id } }));
   });
 });

--- a/src/test/isAuthenticated.test.ts
+++ b/src/test/isAuthenticated.test.ts
@@ -25,6 +25,6 @@ describe('isAuthenticated', async () => {
   it('should return the session', async () => {
     const req = await authenticatedReq();
     const isAuthenticated = await authenticator.isAuthenticated(req);
-    expect(isAuthenticated).toEqual({ ...validResponse, user });
+    expect(isAuthenticated).toEqual({ ...validResponse, user: { id: user.id } });
   });
 });

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -8,6 +8,7 @@ export interface CookieInit {
   user: Partial<User>;
   access_token: string;
   refresh_token: string;
+  token_type: string;
 }
 
 export const getCookieHeader = async (req: Request, cookie: any) => {
@@ -26,7 +27,8 @@ export const getResWithSession = async (
   cookieInit: CookieInit = {
     refresh_token: 'valid',
     access_token: 'valid',
-    user
+    token_type: 'grant',
+    user: { id: user.id }
   }
 ) =>
   fetch(


### PR DESCRIPTION
This PR aims to limit the amount of information stored inside the session by hijacking the protected success method and manipulating the date before we pass it to the original protected success function.

I do consider this change to be a breaking change as it drastically reduces the amount of information we return (and people could have build checks around those). 

The solution is fairly straightforward as @rphlmr mentions in his other PR #20, you would just need to fetch the user inside the loader function.